### PR TITLE
workaround coursier profile activation on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,21 +8,24 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      
+
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
         java-version: '11'
         distribution: 'adopt'
-        
+
     - name: Coursier Cache
       uses: coursier/cache-action@v6
-      
+
     - name: Run tests
       run: sbt test scripted

--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,17 @@ sbtPlugin := true
 
 enablePlugins(ScriptedPlugin)
 scriptedLaunchOpts += s"-Dproject.version=${version.value}"
+scriptedDependencies := {
+  // publish to maven instead of ivy, in order to activate maven profiles on Windows
+  (Test / compile).value
+  publishM2.value
+}
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.4")
 
+val jvmBrotliVersion = "0.2.0"
 libraryDependencies ++= Seq(
-  "com.nixxcode.jvmbrotli" % "jvmbrotli" % "0.2.0",
+  "com.nixxcode.jvmbrotli" % "jvmbrotli" % jvmBrotliVersion
 )
 
 publishTo := sonatypePublishToBundle.value
@@ -38,6 +44,40 @@ pomExtra := {
         <url>https://github.com/enalmada</url>
       </developer>
     </developers>
+    <profiles>
+      <profile>
+        <id>win32-x86-amd64</id>
+        <activation>
+          <os>
+            <family>windows</family>
+            <arch>amd64</arch>
+          </os>
+        </activation>
+        <dependencies>
+          <dependency>
+            <groupId>com.nixxcode.jvmbrotli</groupId>
+            <artifactId>jvmbrotli-win32-x86-amd64</artifactId>
+            <version>{jvmBrotliVersion}</version>
+          </dependency>
+        </dependencies>
+      </profile>
+      <profile>
+        <id>win32-x86</id>
+        <activation>
+          <os>
+            <family>windows</family>
+            <arch>x86</arch>
+          </os>
+        </activation>
+        <dependencies>
+          <dependency>
+            <groupId>com.nixxcode.jvmbrotli</groupId>
+            <artifactId>jvmbrotli-win32-x86</artifactId>
+            <version>{jvmBrotliVersion}</version>
+          </dependency>
+        </dependencies>
+      </profile>
+    </profiles>
 }
 
 import ReleaseTransformations._

--- a/src/sbt-test/brotli/compress/project/plugins.sbt
+++ b/src/sbt-test/brotli/compress/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.dwickern" % "sbt-web-brotli" % sys.props("project.version"))
+resolvers += Resolver.mavenLocal

--- a/src/sbt-test/brotli/exclude/project/plugins.sbt
+++ b/src/sbt-test/brotli/exclude/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.dwickern" % "sbt-web-brotli" % sys.props("project.version"))
+resolvers += Resolver.mavenLocal

--- a/src/sbt-test/brotli/existing/project/plugins.sbt
+++ b/src/sbt-test/brotli/existing/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.dwickern" % "sbt-web-brotli" % sys.props("project.version"))
+resolvers += Resolver.mavenLocal

--- a/src/sbt-test/brotli/include/project/plugins.sbt
+++ b/src/sbt-test/brotli/include/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.dwickern" % "sbt-web-brotli" % sys.props("project.version"))
+resolvers += Resolver.mavenLocal


### PR DESCRIPTION
Work around https://github.com/coursier/coursier/pull/2286 by adding jvmbrotli's Windows JNI libs to `pomExtra`, using `<family>windows</family>` in lower-case.