### PR TITLE
Upgrade to latest sbt-web which changed groupId

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scriptedDependencies := {
   publishM2.value
 }
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.4")
+addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.3")
 
 val jvmBrotliVersion = "0.2.0"
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.3.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
sbt-web 1.5 fixed a memory leak in should run faster as well (because it internally did depend on akka which was removed).

I guess after merging this you want to increase the version to v1.2 or even v2.

Thanks!