### PR TITLE
Replace jvmbrotli with brotli4j

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Coursier Cache
       uses: coursier/cache-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,7 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-
-    - name: Coursier Cache
-      uses: coursier/cache-action@v6
+        cache: 'sbt'
 
     - name: Run tests
       run: sbt test scripted

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ sbt-web-brotli
 [![build](https://github.com/dwickern/sbt-web-brotli/workflows/build/badge.svg)](https://github.com/dwickern/sbt-web-brotli/actions)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.dwickern/sbt-web-brotli/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.dwickern/sbt-web-brotli)
 
-[sbt-web] plugin for brotli-compressing web assets using [jvmbrotli] bindings.
+[sbt-web] plugin for brotli-compressing web assets using [brotli4j] bindings.
 
 Rewritten from [sbt-gzip] sources, thanks to Typesafe/Lightbend.
 Some parts of code, docs, tests are copy-pasted with no changes.
@@ -71,12 +71,22 @@ pipelineStages := Seq(brotli, gzip)
 gzip / excludeFilter ~= { _ || "*.br" }
 ```
 
+Troubleshooting
+-------
+
+If you encounter `java.lang.UnsatisfiedLinkError: Failed to load Brotli native library`
+1. Upgrade to sbt 1.7.3 or later, which includes an important fix [coursier#2286](https://github.com/coursier/coursier/pull/2286)
+2. Make sure you're using a platform supported by [brotli4j]
+3. Make sure Couriser is not disabled (e.g. with the `useCoursier` setting)
+
+Otherwise, you can add the [brotli4j] native library for your platform to `libraryDependencies` in `project/plugins.sbt`.
+
 License
 -------
 
 This code is licensed under the [Apache 2.0 License][apache].
 
-[jvmbrotli]: https://github.com/nixxcode/jvm-brotli
+[brotli4j]: https://github.com/hyperxpro/Brotli4j
 [sbt-gzip]: https://github.com/sbt/sbt-gzip
 [sbt-web]: https://github.com/sbt/sbt-web
 [apache]: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,8 @@ scriptedDependencies := {
 
 addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.5")
 
-val jvmBrotliVersion = "0.2.0"
 libraryDependencies ++= Seq(
-  "com.nixxcode.jvmbrotli" % "jvmbrotli" % jvmBrotliVersion
+  "com.aayushatharva.brotli4j" % "brotli4j" % "1.16.0"
 )
 
 publishTo := sonatypePublishToBundle.value
@@ -44,40 +43,6 @@ pomExtra := {
         <url>https://github.com/enalmada</url>
       </developer>
     </developers>
-    <profiles>
-      <profile>
-        <id>win32-x86-amd64</id>
-        <activation>
-          <os>
-            <family>windows</family>
-            <arch>amd64</arch>
-          </os>
-        </activation>
-        <dependencies>
-          <dependency>
-            <groupId>com.nixxcode.jvmbrotli</groupId>
-            <artifactId>jvmbrotli-win32-x86-amd64</artifactId>
-            <version>{jvmBrotliVersion}</version>
-          </dependency>
-        </dependencies>
-      </profile>
-      <profile>
-        <id>win32-x86</id>
-        <activation>
-          <os>
-            <family>windows</family>
-            <arch>x86</arch>
-          </os>
-        </activation>
-        <dependencies>
-          <dependency>
-            <groupId>com.nixxcode.jvmbrotli</groupId>
-            <artifactId>jvmbrotli-win32-x86</artifactId>
-            <version>{jvmBrotliVersion}</version>
-          </dependency>
-        </dependencies>
-      </profile>
-    </profiles>
 }
 
 import ReleaseTransformations._

--- a/src/main/scala/com/github/dwickern/sbt/brotli/SbtWebBrotli.scala
+++ b/src/main/scala/com/github/dwickern/sbt/brotli/SbtWebBrotli.scala
@@ -1,7 +1,7 @@
 package com.github.dwickern.sbt.brotli
 
-import com.nixxcode.jvmbrotli.common.BrotliLoader
-import com.nixxcode.jvmbrotli.enc.BrotliOutputStream
+import com.aayushatharva.brotli4j.Brotli4jLoader
+import com.aayushatharva.brotli4j.encoder.BrotliOutputStream
 import com.typesafe.sbt.web.SbtWeb
 import com.typesafe.sbt.web.pipeline.Pipeline
 import sbt.Keys._
@@ -31,9 +31,7 @@ object SbtWebBrotli extends AutoPlugin {
   )
 
   private def brotliFiles: Def.Initialize[Task[Pipeline.Stage]] = Def.task {
-    if (!BrotliLoader.isBrotliAvailable) {
-      sys.error("Brotli native library could not be loaded")
-    }
+    Brotli4jLoader.ensureAvailability()
     val targetDir = (brotli / target).value
     val include = (brotli / includeFilter).value
     val exclude = (brotli / excludeFilter).value


### PR DESCRIPTION
Switch to [brotli4j](https://github.com/hyperxpro/Brotli4j) because [jvmbrotli](https://github.com/nixxcode/jvm-brotli) is no longer maintained.

Adds support for macOS M1/aarch64 architecture. See [Supported Platforms](https://github.com/hyperxpro/Brotli4j?tab=readme-ov-file#supported-platforms).

Since brotli4j Maven profiles [use capital letters in the family name](https://github.com/hyperxpro/Brotli4j/blob/ecd291bd6af5abee1636179cc064d04fb0b17c98/natives/pom.xml#L57), it will have the same issue as jvmbrotli https://github.com/coursier/coursier/pull/2286 if using an older version of coursier. I worked around this before in #2 but I won't include a workaround this time. Users will need [coursier v2.1.0-M5-18-gfebf9838c](https://github.com/coursier/coursier/releases/tag/v2.1.0-M5-18-gfebf9838c) or later, which is included in [sbt 1.7.3](https://github.com/sbt/sbt/releases/tag/v1.7.3) or later.