### PR TITLE
replace setup-java with coursier/setup-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
       uses: coursier/setup-action@v1
       with:
         jvm: 11
+        apps: sbt
 
     - name: Run tests
       run: sbt test scripted

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v4
+    - name: Restore cache
+      uses: coursier/cache-action@v6
+
+    - name: Setup Java & Scala
+      uses: coursier/setup-action@v1
       with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'sbt'
+        jvm: 11
 
     - name: Run tests
       run: sbt test scripted


### PR DESCRIPTION
Fixes the build failure now that `macos-14` was promoted to `macos-latest`.

https://github.com/actions/setup-java/issues/627